### PR TITLE
Preemptive body reading

### DIFF
--- a/error.go
+++ b/error.go
@@ -65,10 +65,21 @@ func BucketAlreadyOwnedByYouError(r *http.Request) *Error {
 	return NewError(r, http.StatusConflict, "BucketAlreadyOwnedByYou", "The bucket you tried to create already exists, and you own it.")
 }
 
+// EntityTooLargeError creates a new S3 error with a standard EntityTooLarge
+// S3 code.
+func EntityTooLargeError(r *http.Request) *Error {
+	return NewError(r, http.StatusBadRequest, "EntityTooLarge", "Your proposed upload exceeds the maximum allowed object size.")
+}
+
 // EntityTooSmallError creates a new S3 error with a standard EntityTooSmall
 // S3 code.
 func EntityTooSmallError(r *http.Request) *Error {
 	return NewError(r, http.StatusBadRequest, "EntityTooSmall", "Your proposed upload is smaller than the minimum allowed object size. Each part must be at least 5 MB in size, except the last part.")
+}
+
+// IncompleteBodyError creates a new S3 error with a standard IncompleteBody S3 code.
+func IncompleteBodyError(r *http.Request) *Error {
+	return NewError(r, http.StatusBadRequest, "IncompleteBody", "You did not provide the number of bytes specified by the Content-Length HTTP header.")
 }
 
 // InternalError creates a new S3 error with a standard InternalError S3 code.
@@ -122,6 +133,18 @@ func MalformedXMLError(r *http.Request) *Error {
 // MethodNotAllowed S3 code.
 func MethodNotAllowedError(r *http.Request) *Error {
 	return NewError(r, http.StatusMethodNotAllowed, "MethodNotAllowed", "The specified method is not allowed against this resource.")
+}
+
+// MissingContentLengthError creates a new S3 error with a standard
+// MissingContentLength S3 code.
+func MissingContentLengthError(r *http.Request) *Error {
+	return NewError(r, http.StatusBadRequest, "MissingContentLength", "You must provide the Content-Length HTTP header.")
+}
+
+// MissingRequestBodyError creates a new S3 error with a standard
+// MissingRequestBodyError S3 code.
+func MissingRequestBodyError(r *http.Request) *Error {
+	return NewError(r, http.StatusBadRequest, "MissingRequestBodyError", "Request body is empty.")
 }
 
 // NoSuchBucketError creates a new S3 error with a standard NoSuchBucket S3

--- a/error.go
+++ b/error.go
@@ -170,10 +170,16 @@ func NotImplementedError(r *http.Request) *Error {
 	return NewError(r, http.StatusNotImplemented, "NotImplemented", "This functionality is not implemented.")
 }
 
+// RequestTimeoutError creates a new S3 error with a standard RequestTimeout
+// S3 code.
+func RequestTimeoutError(r *http.Request) *Error {
+	return NewError(r, http.StatusBadRequest, "RequestTimeout", "Your socket connection to the server was not read from or written to within the timeout period.")
+}
+
 // RequestTimeTooSkewedError creates a new S3 error with a standard
 // RequestTimeTooSkewed S3 code.
 func RequestTimeTooSkewedError(r *http.Request) *Error {
-	return NewError(r, http.StatusForbidden, "RequestTimeTooSkewed", "The difference between the request time and the server's time is too large. ")
+	return NewError(r, http.StatusForbidden, "RequestTimeTooSkewed", "The difference between the request time and the server's time is too large.")
 }
 
 // SignatureDoesNotMatchError creates a new S3 error with a standard

--- a/error.go
+++ b/error.go
@@ -138,7 +138,7 @@ func MethodNotAllowedError(r *http.Request) *Error {
 // MissingContentLengthError creates a new S3 error with a standard
 // MissingContentLength S3 code.
 func MissingContentLengthError(r *http.Request) *Error {
-	return NewError(r, http.StatusBadRequest, "MissingContentLength", "You must provide the Content-Length HTTP header.")
+	return NewError(r, http.StatusLengthRequired, "MissingContentLength", "You must provide the Content-Length HTTP header.")
 }
 
 // MissingRequestBodyError creates a new S3 error with a standard

--- a/example/controllers/multipart.go
+++ b/example/controllers/multipart.go
@@ -228,27 +228,3 @@ func (c Controller) UploadMultipartChunk(r *http.Request, name, key, uploadID st
 	multipart[partNumber] = bytes
 	return fmt.Sprintf("%x", hash), nil
 }
-
-func (c Controller) DeleteMultipartChunk(r *http.Request, name, key, uploadID string, partNumber int) error {
-	c.logger.Tracef("DeleteMultipartChunk: name=%+v, key=%+v, uploadID=%+v partNumber=%+v", name, key, uploadID, partNumber)
-
-	c.DB.Lock.Lock()
-	defer c.DB.Lock.Unlock()
-
-	bucket, err := c.DB.Bucket(r, name)
-	if err != nil {
-		return err
-	}
-
-	multipart, err := bucket.Multipart(r, key, uploadID)
-	if err != nil {
-		return err
-	}
-
-	if _, ok := multipart[partNumber]; !ok {
-		return s2.InvalidPartError(r)
-	}
-
-	delete(multipart, partNumber)
-	return nil
-}

--- a/example/main.go
+++ b/example/main.go
@@ -21,7 +21,7 @@ func main() {
 
 	controller := controllers.NewController(db, logger)
 
-	s3 := s2.NewS2(logger)
+	s3 := s2.NewS2(logger, 0)
 	s3.Auth = controller
 	s3.Service = controller
 	s3.Bucket = controller

--- a/example/main.go
+++ b/example/main.go
@@ -34,6 +34,7 @@ func main() {
 		Addr: ":8080",
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			logger.Infof("%s %s", r.Method, r.RequestURI)
+			logger.Infof("headers: %+v", r.Header)
 			router.ServeHTTP(w, r)
 		}),
 		ErrorLog:     stdlog.New(logger.Writer(), "", 0),

--- a/example/main.go
+++ b/example/main.go
@@ -21,7 +21,7 @@ func main() {
 
 	controller := controllers.NewController(db, logger)
 
-	s3 := s2.NewS2(logger, 0)
+	s3 := s2.NewS2(logger, 0, 5*time.Second)
 	s3.Auth = controller
 	s3.Service = controller
 	s3.Bucket = controller

--- a/example/test/ignore.conf
+++ b/example/test/ignore.conf
@@ -125,12 +125,9 @@ s3tests_boto3.functional.test_s3.test_multipart_upload_resend_part
 # be fixable, e.g. if the s2 server is run behind a reverse proxy.
 s3tests_boto3.functional.test_s3.test_ranged_request_invalid_range
 s3tests_boto3.functional.test_s3.test_ranged_request_empty_object
-s3tests.functional.test_headers.test_object_create_bad_contentlength_mismatch_above
 s3tests_boto3.functional.test_headers.test_object_create_bad_expect_mismatch
-s3tests_boto3.functional.test_headers.test_object_create_bad_contentlength_mismatch_above
 s3tests_boto3.functional.test_headers.test_bucket_create_bad_expect_mismatch
 s3tests_boto3.functional.test_s3.test_get_object_ifmodifiedsince_failed
-s3tests.functional.test_headers.test_object_create_bad_contentlength_none
 s3tests_boto3.functional.test_s3.test_get_object_ifmatch_failed
 s3tests_boto3.functional.test_s3.test_100_continue
 s3tests_boto3.functional.test_s3.test_put_object_ifmatch_failed
@@ -139,6 +136,7 @@ s3tests_boto3.functional.test_s3.test_put_object_ifnonmatch_failed
 s3tests_boto3.functional.test_s3.test_put_object_ifnonmatch_overwrite_existed_failed
 s3tests_boto3.functional.test_s3.test_post_object_upload_larger_than_chunk
 s3tests_boto3.functional.test_s3.test_object_anon_put_write_access
+s3tests_boto3.functional.test_s3.test_get_object_ifunmodifiedsince_good
 
 # Ignore all website tests, since the functionality isn't supported
 s3tests.functional.test_s3_website
@@ -197,6 +195,7 @@ s3tests_boto3.functional.test_headers.test_object_create_bad_date_none_aws2
 s3tests_boto3.functional.test_headers.test_bucket_create_bad_authorization_invalid_aws2
 s3tests_boto3.functional.test_headers.test_bucket_create_bad_date_none_aws2
 s3tests.functional.test_headers.test_object_acl_create_contentlength_none
+s3tests.functional.test_headers.test_bucket_create_bad_contentlength_empty
 ## Seems to go against what the docs say
 s3tests.functional.test_headers.test_object_create_date_and_amz_date
 s3tests.functional.test_headers.test_object_create_amz_date_and_no_date

--- a/example/test/ignore.conf
+++ b/example/test/ignore.conf
@@ -171,6 +171,7 @@ s3tests_boto3.functional.test_s3.test_bucket_list_prefix_delimiter_prefix_not_ex
 s3tests_boto3.functional.test_s3.test_bucket_list_prefix_delimiter_delimiter_not_exist
 s3tests_boto3.functional.test_s3.test_bucket_list_prefix_delimiter_prefix_delimiter_not_exist
 s3tests_boto3.functional.test_s3.test_bucket_recreate_not_overriding
+s3tests_boto3.functional.test_s3.test_multipart_resend_first_finishes_last
 
 # These are ignored because s2 supports bucket names that s3 itself does not
 s3tests_boto3.functional.test_s3.test_bucket_delete_nonempty
@@ -196,6 +197,11 @@ s3tests_boto3.functional.test_headers.test_bucket_create_bad_authorization_inval
 s3tests_boto3.functional.test_headers.test_bucket_create_bad_date_none_aws2
 s3tests.functional.test_headers.test_object_acl_create_contentlength_none
 s3tests.functional.test_headers.test_bucket_create_bad_contentlength_empty
+s3tests_boto3.functional.test_headers.test_object_create_bad_contentlength_empty
 ## Seems to go against what the docs say
 s3tests.functional.test_headers.test_object_create_date_and_amz_date
 s3tests.functional.test_headers.test_object_create_amz_date_and_no_date
+## Uses a bad method
+s3tests_boto3.functional.test_headers.test_object_create_bad_contentlength_mismatch_below_aws2
+## References a function that doesn't exist
+s3tests_boto3.functional.test_headers.test_object_create_bad_contentlength_mismatch_above

--- a/s2.go
+++ b/s2.go
@@ -228,17 +228,9 @@ func (h *S2) authV4(w http.ResponseWriter, r *http.Request, auth string) error {
 	dateRegionKey := hmacSHA256(dateKey, region)
 	dateRegionServiceKey := hmacSHA256(dateRegionKey, "s3")
 	signingKey := hmacSHA256(dateRegionServiceKey, "aws4_request")
-	h.logger.Debugf("dateKey: %x", dateKey)
-	h.logger.Debugf("dateRegionKey: %x", dateRegionKey)
-	h.logger.Debugf("dateRegionServiceKey: %x", dateRegionServiceKey)
 
 	// step 3: construct & verify the signature
 	signature := hmacSHA256(signingKey, stringToSign)
-
-	h.logger.Debugf("canonicalRequest:\n%s", canonicalRequest)
-	h.logger.Debugf("stringToSign:\n%s", stringToSign)
-	h.logger.Debugf("signingKey: %x", signingKey)
-	h.logger.Debugf("signature: %x", signature)
 
 	if expectedSignature != fmt.Sprintf("%x", signature) {
 		return SignatureDoesNotMatchError(r)
@@ -325,8 +317,6 @@ func (h *S2) authV2(w http.ResponseWriter, r *http.Request, auth string) error {
 
 	stringToSign := strings.Join(stringToSignParts, "\n")
 	signature := base64.StdEncoding.EncodeToString(hmacSHA1([]byte(*secretKey), stringToSign))
-	h.logger.Debugf("stringToSign:\n%s", stringToSign)
-	h.logger.Debugf("signature: %s", signature)
 
 	if expectedSignature != signature {
 		return AccessDeniedError(r)
@@ -339,14 +329,11 @@ func (h *S2) authV2(w http.ResponseWriter, r *http.Request, auth string) error {
 }
 
 func (h *S2) authMiddleware(next http.Handler) http.Handler {
-	// Verifies auth using AWS' signature v4. See here for a guide:
-	// https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html
-	// Much of the code is built off of smartystreets/go-aws-auth, which does
-	// signing from the client-side:
+	// Verifies auth using AWS' v2 and v4 auth mechanisms. Much of the code is
+	// built off of smartystreets/go-aws-auth, which does signing from the
+	// client-side:
 	// https://github.com/smartystreets/go-aws-auth
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		h.logger.Debugf("headers: %v", r.Header)
-
 		auth := r.Header.Get("authorization")
 
 		passed := true
@@ -357,6 +344,7 @@ func (h *S2) authMiddleware(next http.Handler) http.Handler {
 			err = h.authV2(w, r, auth)
 		} else {
 			passed, err = h.Auth.CustomAuth(r)
+			vars := mux.Vars(r)
 			vars["authMethod"] = "custom"
 		}
 		if err != nil {

--- a/util.go
+++ b/util.go
@@ -169,8 +169,7 @@ func hmacSHA256(key []byte, content string) []byte {
 }
 
 func requireContentLength(r *http.Request) error {
-	contentLength := r.Header.Get("content-length")
-	if contentLength == "" {
+	if _, ok := singleHeader(r, "Content-Length"); !ok {
 		return MissingContentLengthError(r)
 	}
 	return nil

--- a/util.go
+++ b/util.go
@@ -175,3 +175,17 @@ func requireContentLength(r *http.Request) error {
 	}
 	return nil
 }
+
+// singleHeader gets a single header value. This is used in places instead of
+// `r.Header.Get()` because it differentiates between missing headers versus
+// empty header values.
+func singleHeader(r *http.Request, name string) (string, bool) {
+	values, ok := r.Header[name]
+	if !ok {
+		return "", false
+	}
+	if len(values) != 1 {
+		return "", false
+	}
+	return values[0], true
+}


### PR DESCRIPTION
Read the request body ahead-of-time (in middleware) to more easily catch various error cases:
* Incorrect content lengths
* Broken connections when reading the body
* Mismatch with `Content-MD5` or `x-amz-content-sha256` headers