### PR TITLE
More standard delete markers

### DIFF
--- a/examples/sql/controllers/bucket.go
+++ b/examples/sql/controllers/bucket.go
@@ -116,7 +116,7 @@ func (c *Controller) ListObjectVersions(r *http.Request, name, prefix, keyMarker
 
 		// s3tests expects the listings to be ordered by update date
 		sort.Slice(objects, func(i, j int) bool {
-			return objects[i].UpdatedAt.After(objects[j].UpdatedAt)
+			return objects[i].ID > objects[j].ID
 		})
 
 		for _, object := range objects {

--- a/examples/sql/controllers/bucket.go
+++ b/examples/sql/controllers/bucket.go
@@ -140,7 +140,7 @@ func (c *Controller) ListObjectVersions(r *http.Request, name, prefix, keyMarker
 				result.DeleteMarkers = append(result.DeleteMarkers, s2.DeleteMarker{
 					Key:          object.Key,
 					Version:      object.Version,
-					IsLatest:     latestObject.Version == object.Version,
+					IsLatest:     latestObject.ID == object.ID,
 					LastModified: models.Epoch,
 					Owner:        models.GlobalUser,
 				})
@@ -148,7 +148,7 @@ func (c *Controller) ListObjectVersions(r *http.Request, name, prefix, keyMarker
 				result.Versions = append(result.Versions, s2.Version{
 					Key:          object.Key,
 					Version:      object.Version,
-					IsLatest:     latestObject.Version == object.Version,
+					IsLatest:     latestObject.ID == object.ID,
 					LastModified: models.Epoch,
 					ETag:         object.ETag,
 					Size:         uint64(len(object.Content)),

--- a/examples/sql/controllers/multipart.go
+++ b/examples/sql/controllers/multipart.go
@@ -151,22 +151,25 @@ func (c *Controller) CompleteMultipart(r *http.Request, name, key, uploadID stri
 			content = append(content, uploadPart.Content...)
 		}
 
-		version := ""
 		if bucket.Versioning == s2.VersioningEnabled {
-			version = util.RandomString(10)
+			object, err := models.CreateVersionedObjectContent(tx, bucket.ID, key, util.RandomString(10), content)
+			if err != nil {
+				return err
+			}
+
+			result.ETag = object.ETag
+			result.Version = object.Version
+		} else {
+			object, err := models.UpsertUnversionedObjectContent(tx, bucket.ID, key, content)
+			if err != nil {
+				return err
+			}
+
+			result.ETag = object.ETag
 		}
 
-		obj, err := models.UpsertObject(tx, bucket.ID, key, version, content)
-		if err != nil {
-			return err
-		}
 		if err := models.DeleteUpload(tx, bucket.ID, key, uploadID); err != nil {
 			return err
-		}
-
-		result.ETag = obj.ETag
-		if bucket.Versioning == s2.VersioningEnabled {
-			result.Version = obj.Version
 		}
 
 		return nil

--- a/examples/sql/controllers/multipart.go
+++ b/examples/sql/controllers/multipart.go
@@ -151,22 +151,18 @@ func (c *Controller) CompleteMultipart(r *http.Request, name, key, uploadID stri
 			content = append(content, uploadPart.Content...)
 		}
 
+		version := ""
 		if bucket.Versioning == s2.VersioningEnabled {
-			object, err := models.CreateVersionedObjectContent(tx, bucket.ID, key, util.RandomString(10), content)
-			if err != nil {
-				return err
-			}
-
-			result.ETag = object.ETag
-			result.Version = object.Version
-		} else {
-			object, err := models.UpsertUnversionedObjectContent(tx, bucket.ID, key, content)
-			if err != nil {
-				return err
-			}
-
-			result.ETag = object.ETag
+			version = util.RandomString(10)
+			result.Version = version
 		}
+
+		object, err := models.CreateObjectContent(tx, bucket.ID, key, version, content)
+		if err != nil {
+			return err
+		}
+
+		result.ETag = object.ETag
 
 		if err := models.DeleteUpload(tx, bucket.ID, key, uploadID); err != nil {
 			return err

--- a/examples/sql/controllers/multipart.go
+++ b/examples/sql/controllers/multipart.go
@@ -151,7 +151,7 @@ func (c *Controller) CompleteMultipart(r *http.Request, name, key, uploadID stri
 			content = append(content, uploadPart.Content...)
 		}
 
-		version := ""
+		version := "null"
 		if bucket.Versioning == s2.VersioningEnabled {
 			version = util.RandomString(10)
 			result.Version = version

--- a/examples/sql/controllers/object.go
+++ b/examples/sql/controllers/object.go
@@ -100,7 +100,7 @@ func (c *Controller) PutObject(r *http.Request, name, key string, reader io.Read
 				}
 			}
 
-			object, err = models.CreateObjectContent(tx, bucket.ID, key, "", bytes)
+			object, err = models.CreateObjectContent(tx, bucket.ID, key, "null", bytes)
 			if err != nil {
 				return err
 			}
@@ -146,7 +146,12 @@ func (c *Controller) DeleteObject(r *http.Request, name, key, version string) (*
 		if object.DeleteMarker {
 			result.DeleteMarker = true
 		} else {
-			object, err = models.CreateObjectDeleteMarker(tx, bucket.ID, key, version)
+			deleteVersion := "null"
+			if bucket.Versioning == s2.VersioningEnabled {
+				deleteVersion = util.RandomString(10)
+			}
+
+			object, err = models.CreateObjectDeleteMarker(tx, bucket.ID, key, deleteVersion)
 			if err != nil {
 				return err
 			}

--- a/examples/sql/main.go
+++ b/examples/sql/main.go
@@ -20,13 +20,6 @@ func main() {
 	}
 	defer db.Close()
 
-	// dbLogger := logrus.WithFields(logrus.Fields{
-	// 	"source": "gorm",
-	// }).Writer()
-	// defer dbLogger.Close()
-	// db.LogMode(true)
-	//db.SetLogger(stdlog.New(dbLogger, "", 0))
-
 	models.Init(db)
 
 	logrus.SetLevel(logrus.TraceLevel)

--- a/examples/sql/models/models.go
+++ b/examples/sql/models/models.go
@@ -57,7 +57,7 @@ type Object struct {
 
     BucketID uint   `gorm:"not null"`
     Key      string `gorm:"not null,index:idx_object_key"`
-    Version  string `gorm:"index:idx_object_version"`
+    Version  string `gorm:"not null,index:idx_object_version"`
 
     DeleteMarker bool `gorm:"not null"`
 

--- a/examples/sql/models/models.go
+++ b/examples/sql/models/models.go
@@ -52,8 +52,7 @@ func GetBucket(db *gorm.DB, name string) (Bucket, error) {
 }
 
 type Object struct {
-    ID        uint      `gorm:"primary_key"`
-    UpdatedAt time.Time `gorm:"index"`
+    ID uint `gorm:"primary_key"`
 
     BucketID uint   `gorm:"not null"`
     Key      string `gorm:"not null,index:idx_object_key"`
@@ -73,7 +72,7 @@ func GetObject(db *gorm.DB, bucketID uint, key, version string) (Object, error) 
 
 func GetLatestObject(db *gorm.DB, bucketID uint, key string) (Object, error) {
     var object Object
-    err := db.Order("updated_at DESC").Where("bucket_id = ? AND key = ?", bucketID, key).First(&object).Error
+    err := db.Order("ID DESC").Where("bucket_id = ? AND key = ?", bucketID, key).First(&object).Error
     return object, err
 }
 

--- a/object.go
+++ b/object.go
@@ -82,9 +82,6 @@ func (h *objectHandler) get(w http.ResponseWriter, r *http.Request) {
 	bucket := vars["bucket"]
 	key := vars["key"]
 	versionId := r.FormValue("versionId")
-	if versionId == "null" {
-		versionId = ""
-	}
 
 	result, err := h.controller.GetObject(r, bucket, key, versionId)
 	if err != nil {
@@ -138,9 +135,6 @@ func (h *objectHandler) del(w http.ResponseWriter, r *http.Request) {
 	bucket := vars["bucket"]
 	key := vars["key"]
 	versionId := r.FormValue("versionId")
-	if versionId == "null" {
-		versionId = ""
-	}
 
 	result, err := h.controller.DeleteObject(r, bucket, key, versionId)
 	if err != nil {


### PR DESCRIPTION
Rewrite delete markers in the example project to be closer to the way s3 behaves. Rather than relying on gorm soft+hard deletes, this insert delete marker entries into the database.