### PR TITLE
Support empty credentials in auth V4

### DIFF
--- a/s2.go
+++ b/s2.go
@@ -38,7 +38,7 @@ var (
 	authV2HeaderValidator = regexp.MustCompile(`^AWS ([^:]+):(.+)$`)
 	// authV4HeaderValidator is a regex for validating the authorization
 	// header when using AWs' auth V4
-	authV4HeaderValidator = regexp.MustCompile(`^AWS4-HMAC-SHA256 Credential=([^/]+)/([^/]+)/([^/]+)/s3/aws4_request, SignedHeaders=([^,]+), Signature=(.+)$`)
+	authV4HeaderValidator = regexp.MustCompile(`^AWS4-HMAC-SHA256 Credential=([^/]*)/([^/]*)/([^/]*)/s3/aws4_request, SignedHeaders=([^,]+), Signature=(.+)$`)
 
 	// subresourceQueryParams is a list of query parameters that are
 	// considered queries for "subresources" in S3. This is used in


### PR DESCRIPTION
Looser regex matching for auth v4, to support auth with empty credentials