### PR TITLE
New API

### DIFF
--- a/examples/sql/README.md
+++ b/examples/sql/README.md
@@ -4,4 +4,4 @@ This example builds off of s2 and [gorm](http://gorm.io/) to provide an S3-like 
 
 ## Tests
 
-To run tests, start the server with `make run`. Then, in a separate shell, run `make test`. After the tests complete, stats will be printed out regarding which tests failed. Complete logs are available in `test/runs`.
+To run tests, start the server with `make run`. Then, in a separate shell, run `conformance-test`. After the tests complete, stats will be printed out regarding which tests failed. Complete logs are available in `test/runs`.

--- a/service.go
+++ b/service.go
@@ -18,7 +18,7 @@ type Bucket struct {
 
 // ListBucketsResult is a response from a ListBucket call
 type ListBucketsResult struct {
-	XMLName xml.Name `xml:"ListAllMyBucketsResult"`
+	XMLName xml.Name `xml:"ListBucketsOutput"`
 	// Owner is the owner of the buckets
 	Owner *User `xml:"Owner"`
 	// Buckets are a list of buckets under the given owner


### PR DESCRIPTION
s3 changed around its API a bit - at the very least for bucket listing (from [this](https://docs.aws.amazon.com/AmazonS3/latest/API/archive-RESTServiceGET.html#archive-RESTServiceGET-examples) to [this](https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBuckets.html).)

This PR addresses those changes.