### PR TITLE
Move etag middleware after auth check

### DIFF
--- a/s2.go
+++ b/s2.go
@@ -504,11 +504,11 @@ func (h *S2) Router() *mux.Router {
 	}
 
 	router := mux.NewRouter()
-	router.Use(h.etagMiddleware)
 	router.Use(h.requestIDMiddleware)
 	if h.Auth != nil {
 		router.Use(h.authMiddleware)
 	}
+	router.Use(h.etagMiddleware)
 	router.Use(h.bodyReadingMiddleware)
 
 	router.Path(`/`).Methods("GET", "HEAD").HandlerFunc(serviceHandler.get)


### PR DESCRIPTION
etag middleware needs to be after the auth check or else a `403 SignatureDoesNotMatch` is returned