### PR TITLE
Add unquoted entity tag test

### DIFF
--- a/integration/integration.py
+++ b/integration/integration.py
@@ -32,7 +32,7 @@ def main():
         with open(os.path.join(TESTDATA, "small.txt"), "w") as f:
             f.write("x")
         with open(os.path.join(TESTDATA, "large.txt"), "w") as f:
-            f.write("x" * (65 * 1024 * 1024))
+            f.write("x" * (10 * 1024 * 1024))
 
     url = urlparse(args.address)
 

--- a/integration/python/requirements.txt
+++ b/integration/python/requirements.txt
@@ -1,3 +1,4 @@
 boto3==1.13.9
 minio==5.0.10
 pytest==5.4.2
+requests==2.27.1

--- a/integration/python/test.py
+++ b/integration/python/test.py
@@ -49,8 +49,8 @@ def test_boto_lib():
 
 def test_minio_lib():
     pool_manager = urllib3.PoolManager(
-        timeout=120.0,
-        retries=urllib3.Retry(total=10),
+        timeout=30.0,
+        retries=urllib3.Retry(total=3),
     )
 
     client = minio.Minio(


### PR DESCRIPTION
This adds some testing that unquoted etags work in the python integration tests. This test is a followup for #31.

It we could fit CI into this repo, but I don't know how that would work.